### PR TITLE
fix sample

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,9 +18,9 @@ class App extends Component {
         const client = createTweekClient("https://tweek.mysoluto.com/configurations")
         const tweekRepository = new TweekRepository({client});
 
-        tweekRepository.init()
-          .then(() => connect(tweekRepository))
-          .then(() => this.setState({isReady: true}));
+        await connect(tweekRepository);
+        await tweekRepository.refresh();
+        await this.setState({isReady: true});
     }
 
     render() {


### PR DESCRIPTION
`init()` method does not exist anymore
Also, refresh is required in order to start using `withTweekKeys()`

Also changed Promise to `async/await`

Solving issue #2 